### PR TITLE
Open file error

### DIFF
--- a/copy_file_link.py
+++ b/copy_file_link.py
@@ -20,13 +20,9 @@ if len(sys.argv) == 3:
         print("Error: That does not look to be a file on dropbox")
         input()
     else:
-        if command in "Full":
+        if command in "Full" or command in "Dir_Full":
             full_path = full_path.replace(match.group(0), "C:\\Users\\^^^%username^^^%\\Dropbox (Springboard)\\")
-        elif command in "Partial":
-            full_path = full_path.replace(match.group(0), "Dropbox (Springboard)\\")
-        elif command in "Dir_Full":
-            full_path = full_path.replace(match.group(0), "C:\\Users\\^^^%username^^^%\\Dropbox (Springboard)\\")
-        elif command in "Dir_Partial":
+        elif command in "Partial" or command in "Dir_Partial":
             full_path = full_path.replace(match.group(0), "Dropbox (Springboard)\\")
         else:
             print("Error: Command not supported")

--- a/upissue.py
+++ b/upissue.py
@@ -1,60 +1,70 @@
-import sys;
-import os;
-import re;
-import shutil;
+import sys
+import os
+import re
+import shutil
 
-if len(sys.argv) == 3 :
+if len(sys.argv) == 3:
     split_path = os.path.split(sys.argv[1])
     upissue = sys.argv[2]
     old_file = split_path[1]
     print("Old Filename: " + old_file)
     path = split_path[0]
-    old_file_parts = re.split(r'([A-Z]{3})-([0-9]{5})-rev([A-Z])([0-9]*) ',old_file)
+    old_file_parts = re.split(r'([A-Z]{3})-([0-9]{5})-rev([A-Z])([0-9]*) ', old_file)
 
-    if old_file_parts[4] == '' :
+    if old_file_parts[4] == '':
         old_file_parts[4] = '0'
-    
-    if len(old_file_parts) == 6 :
-        if upissue in "Draft" :
-            print ("Draft Version upissue")
-            if (old_file_parts[4] == '0') :
-                if (old_file_parts[3] == 'Z') :
+
+    if len(old_file_parts) == 6:
+        if upissue in "Draft":
+            print("Draft Version upissue")
+            if old_file_parts[4] == '0':
+                if old_file_parts[3] == 'Z':
                     print("Error: Existing version is at Z. Sorry but I've not been told where we go after Z!")
                     input()
                     exit()
-                major_version = chr(ord(old_file_parts[3])+1)
+                major_version = chr(ord(old_file_parts[3]) + 1)
                 minor_version = 1
-            else :
+            else:
                 major_version = old_file_parts[3]
-                minor_version = int(old_file_parts[4])+1
-            new_file = "%s-%s-rev%s%d %s" % (old_file_parts[1],old_file_parts[2],major_version,minor_version,old_file_parts[5])
+                minor_version = int(old_file_parts[4]) + 1
+            new_file = "%s-%s-rev%s%d %s" % (
+                old_file_parts[1], old_file_parts[2], major_version, minor_version, old_file_parts[5])
             print("New Filename: " + new_file)
-            if os.path.isfile(path + "/" + new_file) == 0 :
+            release_file = "%s-%s-rev%s %s" % (
+                old_file_parts[1], old_file_parts[2], major_version, old_file_parts[5])
+            if os.path.isfile(path + "/" + new_file) is True:
+                print("Error: New file already exists")
+            elif os.path.isfile(path + "/" + release_file) is True:
+                print("Error: This draft has already been released")
+            else:
                 shutil.copy(path + "/" + old_file, path + "/" + new_file)
                 print("File copied OK")
-            else :
-                print("Error: New file already exists")
-        elif upissue in "Release" :
-            print ("Release Version upissue")
-            if (old_file_parts[4] == '0') :
+        elif upissue in "Release":
+            print("Release Version upissue")
+            if old_file_parts[4] == '0':
                 print("Error: This is already a released document")
                 input()
                 exit()
-            new_file = "%s-%s-rev%s %s" % (old_file_parts[1],old_file_parts[2],old_file_parts[3],old_file_parts[5])
+            new_file = "%s-%s-rev%s %s" % (old_file_parts[1], old_file_parts[2], old_file_parts[3], old_file_parts[5])
             print("New Filename: " + new_file)
-            if os.path.isfile(path + "/" + new_file) == 0 :
-                os.rename(path + "/" + old_file, path + "/" + new_file)
-                print("File renamed OK")
-            else :
+            if os.path.isfile(path + "/" + new_file) == 0:
+                try:
+                    os.rename(path + "/" + old_file, path + "/" + new_file)
+                    print("File renamed OK")
+                except PermissionError:
+                    print("Error: File is open. Please close the file and try again.")
+                    input()
+                    exit()
+            else:
                 print("Error: New file already exists")
-        else :
-            print ("Error: Upissue method undefined")
+        else:
+            print("Error: Upissue method undefined")
             input()
             exit()
-    else :
+    else:
         print("Error: Filename was not as expected")
 
-else :
-    print("Error: Incorrect number of arguements passed in")
+else:
+    print("Error: Incorrect number of arguments passed in")
 
 input()


### PR DESCRIPTION
Handles the error thrown when trying to rename and open file.
Prevents user from continuing to upissue draft documents which have already been released.
Reformats the if statments in copy_file_link.py as the commands to copy a file path or directory path are the same.